### PR TITLE
Improve graph for repos with less than 15 pages of stargazers

### DIFF
--- a/src/getStarHistory.js
+++ b/src/getStarHistory.js
@@ -41,14 +41,14 @@ async function generateUrls(repo) {
 
   // used to calculate total stars for this page
   const pageIndexes = pageNum <= sampleNum ?
-    range(pageNum) :
+    range(pageNum).slice(1, pageNum) :
     range(sampleNum).map(n => Math.round(n / sampleNum * pageNum) - 1); // for bootstrap bug
 
   // store sampleUrls to be rquested
   const sampleUrls = pageIndexes.map(pageIndex => `${initUrl}?page=${pageIndex}`);
 
   console.log("pageIndexes", pageIndexes);
-  return { sampleUrls, pageIndexes };
+  return { firstPage: initRes, sampleUrls, pageIndexes };
 }
 
 /**
@@ -58,13 +58,13 @@ async function generateUrls(repo) {
  */
 async function getStarHistory(repo) {
 
-  const { sampleUrls, pageIndexes } = await generateUrls(repo).catch(e => {
+  const { sampleUrls, pageIndexes, firstPage } = await generateUrls(repo).catch(e => {
     throw e;
   });
 
   // promises to request sampleUrls
 
-  const getArray = sampleUrls.map(url => axiosGit.get(url));
+  const getArray = [firstPage].concat(sampleUrls.map(url => axiosGit.get(url)));
 
   const resArray = await Promise.all(getArray)
     .catch(res => {


### PR DESCRIPTION
This is how a repo with 4 pages looked before (it had 4 points):
![image](https://user-images.githubusercontent.com/4029499/28441172-be40dae4-6da9-11e7-8029-da476e6a83f2.png)

and how it looks now (it has 15 points):
![image](https://user-images.githubusercontent.com/4029499/28441187-cfca4bec-6da9-11e7-8a9c-d2f475ccbd35.png)

This PR basically forces every repo to generate 15 (which is the value defined by the const `sampleNum`) points on the graph

NOTE: repos with more than 15 pages use the same logic as before so they should look exactly the same