### PR TITLE
Fix negative star count

### DIFF
--- a/core/getStarHistory.js
+++ b/core/getStarHistory.js
@@ -69,7 +69,7 @@ async function getStarHistory(repo, token) {
     starHistory = pageIndexes.map((p, i) => {
       return {
         date: resArray[i + 1].data[0].starred_at.slice(0, 10),
-        starNum: 30 * (p - 1),
+        starNum: 30 * ((p === 0 ? 1 : p) - 1), // page 0 also means page 1
       };
     });
   } else {


### PR DESCRIPTION
Fixes #41.

As explained in https://github.com/timqian/star-history/issues/41#issuecomment-515644755, it will appear when the first sample page is 0, i.e. sindresorhus/conf, whose stars are near 480.

| Before         | After    |
| ---------------- | ----------- |
|![star-before](https://user-images.githubusercontent.com/1736154/67504386-da1a8880-f6bb-11e9-81a0-fc4e11a8c3d0.jpg)|![star-after](https://user-images.githubusercontent.com/1736154/67504391-dc7ce280-f6bb-11e9-9a83-8ee10b1d64a2.jpg)|