### PR TITLE
Disallow duplicating charts

### DIFF
--- a/website/src/index.js
+++ b/website/src/index.js
@@ -26,6 +26,13 @@ async function getRepoNameFetchAndDraw() {
     repo = rawRepoStr == '' ? 'timqian/star-history' : rawRepoStr;
   }
 
+  for (let item of data) {
+    if (item.label == repo) {
+      notie.alert({ text: 'This repo is already on the chart', type: 'warning' });
+      return;
+    }
+  }
+
   token = localStorage.getItem('star-history-github-token');
   await fetchDataAndDraw(repo, token);
 }


### PR DESCRIPTION
If you try to draw a repo that is already drawn, star-history will duplicate the charts:

<img width="1023" alt="Screenshot 2020-05-31 at 07 21 53" src="https://user-images.githubusercontent.com/1683279/83344429-8508ba00-a30f-11ea-8b6b-7fdba0b38e10.png">

This patch disallows doing that.